### PR TITLE
Updating the discord link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Contributions are more than welcome! In fact, we're looking for people who want 
 If you have any suggestions, features requests or want to report bugs, kindly open an issue first to discuss what you would like to change. For changes, please open a pull request.
 
 ## 🌐 Community
-Feel free to join our discord at https://discord.gg/5eJkjMMa. 
+Feel free to join our discord at https://discord.gg/p5GxJMYHPT. 
 
 ## 📜 License
 


### PR DESCRIPTION
The discord community link appears twice in the README, 
once on top (was already fixed through a separated issue Link: https://github.com/pywebagent/pywebagent/issues/2, Thank you!)
The second place is in line 102 under the "Community" title. 

This commit updates the "second" discord link with the updated valid link from the previous issue that was already resolved.

